### PR TITLE
Add support for ATShop Version 1 links and custom domains.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atshop-service-models",
-  "version": "0.28.0-rc1",
+  "version": "0.28.0-rc2",
   "description": "TypeScript service models for ATShop",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atshop-service-models",
-  "version": "0.27.0",
+  "version": "0.28.0-rc1",
   "description": "TypeScript service models for ATShop",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/src/models/OrderModel.ts
+++ b/src/models/OrderModel.ts
@@ -237,7 +237,7 @@ class OrderModel extends ServiceModel {
      * Link to view this order as a customer.
      */
     public async customerLink(state?: 'waiting' | 'cancelled') {
-        return this.shop.then((shop) => shop.urlTo(`/order/${this._id}/${state}`));
+        return this.shop.then((shop) => shop.urlTo(`/order/${this._id}/${state}`, this.isLegacy));
     }
 
     /**

--- a/src/models/OrderModel.ts
+++ b/src/models/OrderModel.ts
@@ -71,6 +71,13 @@ class OrderModel extends ServiceModel {
     }
 
     /**
+     * Whether or not this order was created in ATShop v1.
+     */
+    public get isVersion1() {
+        return typeof this.entry.__v === 'undefined';
+    }
+
+    /**
      * Order value in cents.
      */
     public async value() {

--- a/src/models/OrderModel.ts
+++ b/src/models/OrderModel.ts
@@ -73,7 +73,7 @@ class OrderModel extends ServiceModel {
     /**
      * Whether or not this order was created in ATShop v1.
      */
-    public get isVersion1() {
+    public get isLegacy() {
         return typeof this.entry.__v === 'undefined';
     }
 

--- a/src/models/ShopModel.ts
+++ b/src/models/ShopModel.ts
@@ -79,11 +79,13 @@ class ShopModel extends ServiceModel implements FeedbackSummary {
             frontend = this._App.get('legacyFrontend') || frontend;
         }
 
+        let host = `${this.domain}.${frontend.host}`;
+
         if (this.entry.customDomain) {
-            frontend.host = this.entry.customDomain;
+            host = this.entry.customDomain;
         }
 
-        return Helpers.urlTo(frontend.protocol, `${this.domain}.${frontend.host}`, path);
+        return Helpers.urlTo(frontend.protocol, host, path);
     }
 
     /**

--- a/src/models/ShopModel.ts
+++ b/src/models/ShopModel.ts
@@ -72,7 +72,7 @@ class ShopModel extends ServiceModel implements FeedbackSummary {
     /**
      * Build a full-fledged URL to a page on the given path for the current shop.
      */
-    public urlTo(path: string, legacy: boolean) {
+    public urlTo(path: string, legacy?: boolean) {
         let frontend = this._App.get('frontend');
 
         if (legacy) {

--- a/src/models/ShopModel.ts
+++ b/src/models/ShopModel.ts
@@ -72,8 +72,13 @@ class ShopModel extends ServiceModel implements FeedbackSummary {
     /**
      * Build a full-fledged URL to a page on the given path for the current shop.
      */
-    public urlTo(path: string) {
-        const frontend = this._App.get('frontend');
+    public urlTo(path: string, legacy: boolean) {
+        let frontend = this._App.get('frontend');
+
+        if (legacy) {
+            frontend = this._App.get('legacyFrontend') || frontend;
+        }
+
         return Helpers.urlTo(frontend.protocol, `${this.domain}.${frontend.host}`, path);
     }
 

--- a/src/models/ShopModel.ts
+++ b/src/models/ShopModel.ts
@@ -79,6 +79,10 @@ class ShopModel extends ServiceModel implements FeedbackSummary {
             frontend = this._App.get('legacyFrontend') || frontend;
         }
 
+        if (this.entry.customDomain) {
+            frontend.host = this.entry.customDomain;
+        }
+
         return Helpers.urlTo(frontend.protocol, `${this.domain}.${frontend.host}`, path);
     }
 

--- a/src/utility/Service.ts
+++ b/src/utility/Service.ts
@@ -26,6 +26,14 @@ export const config = (options: ConfigOptions) => {
 
     if (options.frontend || !App.get('frontend')) {
         App.set('frontend', {
+            host: 'ats.gg',
+            protocol: 'https',
+            ...options.frontend,
+        });
+    }
+
+    if (options.legacyFrontend || !App.get('legacyFrontend')) {
+        App.set('frontend', {
             host: 'atshop.io',
             protocol: 'https',
             ...options.frontend,

--- a/src/utility/Service.ts
+++ b/src/utility/Service.ts
@@ -33,7 +33,7 @@ export const config = (options: ConfigOptions) => {
     }
 
     if (options.legacyFrontend || !App.get('legacyFrontend')) {
-        App.set('frontend', {
+        App.set('legacyFrontend', {
             host: 'atshop.io',
             protocol: 'https',
             ...options.frontend,

--- a/src/utility/Service.ts
+++ b/src/utility/Service.ts
@@ -1,12 +1,15 @@
 import { Application } from '@feathersjs/feathers';
 import Models from '../interfaces/Models';
 
+interface FrontendDetails {
+    host?: string,
+    protocol?: 'http' | 'https',
+}
+
 export interface ConfigOptions {
     app: Application,
-    frontend?: {
-        host?: string,
-        protocol?: 'http' | 'https',
-    },
+    frontend?: FrontendDetails,
+    legacyFrontend?: FrontendDetails,
     models?: Partial<Models>,
 }
 

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -69,6 +69,14 @@ describe('ShopModel', () => {
         expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop.io/test');
     });
 
+    it('can build URLs using custom domains', async () => {
+        const myShop = await ShopModel.get('ZBAWZE4LzB4RoguGY');
+        myShop.entry.customDomain = 'example.com';
+
+        expect(myShop.urlTo('/test')).toEqual('https://example.com/test');
+        expect(myShop.urlTo('/test', true)).toEqual('https://example.com/test');
+    });
+
     describe('unauthorized users', () => {
         test('cannot fetch the blacklist', async () => {
             await expect(testShop.blacklist.fetch()).rejects.toBeInstanceOf(Forbidden);

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -66,7 +66,7 @@ describe('ShopModel', () => {
     });
 
     it('can build legacy URLs', () => {
-        expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop.io/test');
+        expect(testShop.urlTo('/test', true)).toEqual('https://test-shop.atshop.io/test');
     });
 
     it('can build URLs using custom domains', async () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -65,6 +65,10 @@ describe('ShopModel', () => {
         expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop.io/test');
     });
 
+    it('can build legacy URLs', () => {
+        expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop-legacy.io/test');
+    });
+
     describe('unauthorized users', () => {
         test('cannot fetch the blacklist', async () => {
             await expect(testShop.blacklist.fetch()).rejects.toBeInstanceOf(Forbidden);

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -62,11 +62,11 @@ describe('ShopModel', () => {
     });
 
     test('can build URLs to self', () => {
-        expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop.io/test');
+        expect(testShop.urlTo('/test')).toEqual('https://test-shop.ats.gg/test');
     });
 
     it('can build legacy URLs', () => {
-        expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop-legacy.io/test');
+        expect(testShop.urlTo('/test')).toEqual('https://test-shop.atshop.io/test');
     });
 
     describe('unauthorized users', () => {


### PR DESCRIPTION
Order redirect links would be generated assuming a single frontend base domain. This PR aims to add support for detecting which version generated a given order and redirects the customer to the appropriate domain based on the determined version.

This PR should also address support for shops with custom domains.

- [x] Detect ATShop version used for order creation.
- [x] Use shop custom domains over ATShop subdomains whenever available.
- [ ] Ensure compatibility with development environments.